### PR TITLE
chore(release): bump project version to 1.2-alpha

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.kimia</groupId>
   <artifactId>cv-builder</artifactId>
-  <version>1.1-alpha</version>
+  <version>1.2-alpha</version>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kimia</groupId>
     <artifactId>cv-builder</artifactId>
-    <version>1.1-alpha</version>
+    <version>1.2-alpha</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -15,21 +15,6 @@
 
     <build>
         <plugins>
-            <!--<plugin>
-                &lt;!&ndash; Build an executable JAR &ndash;&gt;
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>com.kimia.builder.ResumeBuilder</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -83,7 +68,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.2.3</version>
+            <version>5.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>


### PR DESCRIPTION
Update project POMs to 1.2-alpha to reflect the new development
version. Also upgrade Apache POI from 5.2.3 to 5.4.1 for security and
bugfix improvements and remove a commented-out maven-jar-plugin block
to clean up the build section now that shade packaging is used. These
changes ensure the build uses the intended release version and a
more recent dependency with fixes.