### PR TITLE
refactor(cohere): make filename generation return hyphenated name+lang

### DIFF
--- a/src/main/java/com/kimia/service/CohereService.java
+++ b/src/main/java/com/kimia/service/CohereService.java
@@ -33,7 +33,7 @@ public class CohereService {
 
     public String generateFileName(String info) {
         return cohere.chat(ChatRequest.builder()
-                .message("What is this person's snake-cased full name in English? Do not include any commentary.")
+                .message("Return the person's full name in English, followed by their preferred language code, all lowercase and separated by hyphens. Do not include any commentary or punctuation.")
                 .chatHistory(List.of(Message.user(ChatMessage.builder().message(info).build())))
                 .build()).getText();
     }


### PR DESCRIPTION
Change the chat prompt to generate filenames so the AI returns person's full name in English followed by preferred language code,
all lowercase and separated by hyphens. Remove instruction to produce a "snake-cased" name and add explicit formatting rules (lowercase, hyphen-separated, no commentary or punctuation).

This clarifies the expected output format for downstream consumers and reduces ambiguity in generated filenames. The change updates the prompt string in CohereService.generateFileName.