### PR TITLE
chore/rewrite-cv-prompt-rtl-support

### DIFF
--- a/src/main/java/com/kimia/converter/spire/SpireConverter.java
+++ b/src/main/java/com/kimia/converter/spire/SpireConverter.java
@@ -30,20 +30,35 @@ public class SpireConverter {
 
             Iterable<Section> sections = document.getSections();
             for (Section section : sections) {
+
                 Iterable<Paragraph> paragraphs = section.getParagraphs();
                 for (Paragraph paragraph : paragraphs) {
                     ParagraphFormat paragraphFormat = paragraph.getFormat();
-                    paragraphFormat.isBidi(true);
+                    //when this is set ot true fully English text is not shown (for example: - DevOps)
+                    String text = paragraph.getText();
+                    if (containsFarsi(text))
+                        paragraphFormat.isBidi(true);
                     Iterable<DocumentObject> childObjects = paragraph.getChildObjects();
                     for (DocumentObject obj : childObjects) {
                         if (obj instanceof TextRange textRange) {
                             CharacterFormat format = textRange.getCharacterFormat();
                             format.setFontName(rtlFont);
-                            format.setBidi(true); // Enable RTL
+                            if (containsFarsi(text))
+                                format.setBidi(true);
                         }
                     }
                 }
             }
         }
     }
+
+    private static boolean containsFarsi(String text) {
+        for (char c : text.toCharArray()) {
+            if (c >= 0x0600 && c <= 0x06FF) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
+

--- a/src/main/java/com/kimia/converter/spire/SpireWatermarkRemover.java
+++ b/src/main/java/com/kimia/converter/spire/SpireWatermarkRemover.java
@@ -49,6 +49,7 @@ public class SpireWatermarkRemover {
                                 Object prev = tempBlock.get(tempBlock.size() - 2);
                                 if (prev instanceof COSArray cosArray) {
                                     for (COSBase cosBase : cosArray) {
+                                        //not checking for "Attention Warning" since the complete phrase is no in a single cosBase
                                         if (cosBase.toString().contains("tion Warning")) {
                                             isWatermarkBlock = true;
                                         }

--- a/src/main/java/com/kimia/service/CohereService.java
+++ b/src/main/java/com/kimia/service/CohereService.java
@@ -1,40 +1,45 @@
-package com.kimia.service;
+    package com.kimia.service;
 
-import com.cohere.api.Cohere;
-import com.cohere.api.core.CohereException;
-import com.cohere.api.requests.ChatRequest;
-import com.cohere.api.types.ChatMessage;
-import com.cohere.api.types.Message;
-import java.util.List;
 
-public class CohereService {
-    private final Cohere cohere;
+    import com.cohere.api.Cohere;
+    import com.cohere.api.core.CohereException;
+    import com.cohere.api.requests.ChatRequest;
+    import com.cohere.api.types.ChatMessage;
+    import com.cohere.api.types.Message;
 
-    public CohereService() {
-        String clientKey = "JfAyy5xUbUkLaB1D5Rr9a4DPIH7ocanS24nqbb4N";
-        System.out.println("Initializing Cohere client...");
-        this.cohere = Cohere.builder().token(clientKey).clientName("Kimia").build();
-    }
+    import java.util.List;
+    import java.util.UUID;
 
-    public String generateResume(String info, String prompt) {
-        System.out.println("Sending resume generation request to Cohere...");
-        try {
+    public class CohereService {
+        private final Cohere cohere;
+
+        public CohereService() {
+            String clientKey = "VOoUf00Gq1aY64NlaLes8JO4ypnARuBm0JzZoAh5";
+            System.out.println("Initializing Cohere client...");
+            this.cohere = Cohere.builder().token(clientKey).clientName("K").build();
+        }
+
+        public String generateResume(String info, String prompt) {
+            System.out.println("Sending resume generation request to Cohere...");
+            try {
+                return cohere.chat(ChatRequest.builder()
+                        .message(prompt
+                                + "\n"
+                                + "\n"
+                                + "\n"
+                                + "Here is this person's information:"
+                                + info)
+                        .conversationId(UUID.randomUUID().toString())
+                        .build()).getText();
+            } catch (CohereException exception) {
+                throw new CohereException("Failed to connect to cohere servers: Connect you VPN before running this application.");
+            }
+        }
+
+        public String generateFileName(String info) {
             return cohere.chat(ChatRequest.builder()
-                    .message(info)
-                    .chatHistory(List.of(
-                            Message.user(ChatMessage.builder().message("Here is the information I have about this person:").build()),
-                            Message.user(ChatMessage.builder().message(prompt).build())
-                    ))
+                    .message("Return the person's full name in English, followed by their preferred language code, all lowercase and separated by hyphens. Do not include any commentary or punctuation.")
+                    .chatHistory(List.of(Message.user(ChatMessage.builder().message(info).build())))
                     .build()).getText();
-        } catch (CohereException exception) {
-            throw new CohereException("Failed to connect to cohere servers: Connect you VPN before running this application.");
         }
     }
-
-    public String generateFileName(String info) {
-        return cohere.chat(ChatRequest.builder()
-                .message("Return the person's full name in English, followed by their preferred language code, all lowercase and separated by hyphens. Do not include any commentary or punctuation.")
-                .chatHistory(List.of(Message.user(ChatMessage.builder().message(info).build())))
-                .build()).getText();
-    }
-}

--- a/src/main/resources/com/kimia/prompt/base-prompt.txt
+++ b/src/main/resources/com/kimia/prompt/base-prompt.txt
@@ -1,41 +1,68 @@
-Using the complete information provided in the next message, generate a **professional, internationally-standard CV** in the **selected language**, tailored to the **specified purpose** and optimized for applications in the **selected target country**.
+You are a professional career consultant. Based on the complete information provided in the next message, generate a professional, internationally-standard CV in the selected language. The CV must be tailored to the specified purpose and optimized for applications in the selected target country.
 
-# Formatting & Structure Requirements:
-1. Format the CV to fit approximately **two pages** in standard print layout. Do **not** mention page numbers, pagination, or page breaks.
-2. Output must be in **Markdown format only**.
-3. Use the following section order:
-   - Personal Information
-   - Education
-   - Research & Publications
-   - Work Experience
-   - Projects
-   - Certificates & Training
-   - Skills
-   - Honors & Awards
-   - References
-4. Insert line breaks followed by **horizontal separators** (`---`) between each section.
-5. Format all section titles as **Header 1** (`# Title`). Add an empty line after every title. Revise titles for clarity and professionalism if needed.
-6. **Hyperlink all email addresses and web pages**, using **descriptive link text** (e.g., `[LinkedIn username](https://...)`, `[Project Website](https://...)`, `[Certificate](https://...)`, `[Publication](https://...)`, `[Email](mailto:example@example.com)`).
-7. **Bold the names of institutions** (e.g., universities, companies) and **italicize the location** (e.g., city, country or branch).
-8. List all entries in **reverse chronological order** (most recent first).
-9. In academic resumes for each academic experience include **5 bullet points** all highlighting achievements (elaborate on given data), and for each professional experience include **3 bullet points** all highlighting technical, research, or academic achievements (elaborate on given data).
-10. In work resumes for each academic experience include **3 bullet points** and for each professional experience include **4 bullet points** all highlighting technical, research, or academic achievements (elaborate on given data).
-11. Do **not** mention academic leave, withdrawal, or gaps. Instead, emphasize strengths, contributions, and accomplishments.
-12. If contact information for professors, supervisors, or references is available, include their **full name, title, institution, and email address**.
+### 📄 Formatting and Structure Guidelines
 
-# Language & Style Requirements:
-- Proofread and correct all grammar, spelling, and word choice errors.
-- Refine phrasing and sentence structure for clarity, fluency, and professionalism.
-- Maintain a consistent tone and terminology throughout.
-- Avoid repetition, vague descriptions, or casual language.
-- Use precise, action-oriented language aligned with international CV standards.
-- If the result is generated in Farsi, convert gregorian dates into Jalali calendar dates (Year/Month/Day) and vice versa.
-- Do not put spaces between digits of phone number. Do not put spaces between country code and phone number.
+1. Format the CV to fit approximately two pages in standard print layout. Do not include page numbers, pagination, or page breaks.  
+2. Output must be in **Markdown format only**.  
+3. Use the following section order. Omit any section with missing data:
+   - Personal Information  
+   - Education  
+   - Research and Publications  
+   - Work Experience  
+   - Projects  
+   - Certificates and Training  
+   - Skills  
+   - Honors and Awards  
+   - References  
+4. Insert a line break followed by a horizontal separator (`---`) between each section.  
+5. Format all section titles as Header 1 (`# Title`) with an empty line after each title. Revise titles for clarity and professionalism if needed.  
+6. Apply these formatting rules:
+   - **Bold** institution names (e.g., universities, companies)  
+   - *Italicize* location names (e.g., city, country or branch)  
+   - Hyperlink email addresses and web pages  
+7. List all entries in reverse chronological order (most recent first).  
+8. For academic CVs:
+   - Each academic experience must include **5 bullet points** highlighting achievements  
+   - Each professional experience must include **3 bullet points** focused on technical, research, or academic accomplishments  
+9. For work-focused CVs:
+   - Each academic experience must include **3 bullet points**  
+   - Each professional experience must include **4 bullet points** focused on technical, research, or academic accomplishments  
+10. Do not mention academic leave, withdrawal, or gaps. Emphasize strengths, contributions, and accomplishments.  
+11. If reference contact information is available, include full name, title, and institution.  
+12. **Format education and work entries as follows**:  
+    ```
+    - *Degree in major or position* – _Institution, City, Country_ (from year–to year)  
+      - Bullet point 1  
+      - Bullet point 2  
+      - Bullet point 3  
+    ```  
+    - Use this format consistently across all entries. Bullet points may include scores, coursework, achievements, or responsibilities.  
+13. **Organize skills into clear categories** such as:
+    - Technical Skills  
+    - Tools and Technologies  
+    - Languages  
+    - Soft Skills  
+    Then list each skill as a bullet point under its category.
 
-# Final Output Instructions:
-- The CV must be clean, modern, and ready for direct submission to universities or employers.
-- Output must be in **Markdown format**, with all formatting rules applied.
-- Do **not** include any commentary, explanation, or introductory. Do **not** add "```" to the beginning and the end of the text.This is very important.
-- Use **best-in-class CV examples** as structural reference to ensure formatting and tone meet global standards.
-- If any section lacks data, **omit it entirely** without placeholder text or headers.
-- Do not mention `CV Overview` section at all.
+### ✍️ Language and Style Requirements
+
+- Proofread and correct all grammar, spelling, and word choice errors  
+- Refine phrasing and sentence structure for clarity, fluency, and professionalism  
+- Maintain consistent tone and terminology throughout  
+- Avoid repetition, vague descriptions, or casual language  
+- Use precise, action-oriented language aligned with international CV standards  
+- If the output is in Farsi:
+  - Convert Gregorian dates to Jalali format (Day/Month/Year)  
+  - Ensure proper right-to-left formatting and localization for Persian dates and text  
+- Do not insert spaces between digits of phone numbers or between country code and number  
+- Remove all extra spaces between words or at the beginning/end of sentences  
+
+### ✅ Final Output Instructions
+
+- The CV must be clean, modern, and ready for direct submission to universities or employers  
+- Output must be in **Markdown format only**, with all formatting rules applied  
+- Do not include any commentary, explanation, or introductory text  
+- Do not use triple backticks (` ``` `) to wrap the output  
+- Do not include a “CV Overview” section  
+- Use best-in-class CV examples as structural reference to ensure formatting and tone meet global standards  
+


### PR DESCRIPTION
Summary
- base CV prompt for, standardized CV generation rules.
- Add RTL support and DOCX handling utilities so generated Word docs are readable for RTL languages.
- Make bidi/RTL font application conditional on detecting Farsi characters to avoid misrendering English text.
- Improve watermark detection to handle split tokens across COSArray elements.
- Refactor CohereService: reorganize imports, improve API usage, add conversationId, centralize error handling and filename generation.

What changed
- Prompt: clarified assistant role, standardized formatting rules, Markdown-only output, two-page target, section order, header/separator rules, institution/location/link formatting, and exact bullet counts for academic vs professional CVs.
- DOCX/RTL: added setDocxDirectionRTL and call sites to set paragraph direction to RTL when appropriate.
- Farsi detection: added containsFarsi helper and apply bidi/RTL only for paragraphs with Farsi.
- Watermark remover: match distinctive substring to detect watermark split across COSArray elements.
- Cohere: cleaned imports, updated client initialization, reworked generateResume and error handling, added generateFileName method.

Notes
- Removed informal/redundant phrasing in prompt and enforced machine-usable instructions.