### PR TITLE
chore/refine-cv-formatting-rules

### DIFF
--- a/src/main/java/com/kimia/converter/spire/SpireConverter.java
+++ b/src/main/java/com/kimia/converter/spire/SpireConverter.java
@@ -1,5 +1,6 @@
 package com.kimia.converter.spire;
 
+import com.kimia.converter.MarkdownConverter;
 import com.spire.doc.*;
 import com.spire.doc.documents.Paragraph;
 import com.spire.doc.fields.TextRange;

--- a/src/main/java/com/kimia/service/FileService.java
+++ b/src/main/java/com/kimia/service/FileService.java
@@ -1,7 +1,6 @@
 package com.kimia.service;
 
 
-
 import com.kimia.converter.MarkdownConverter;
 import com.kimia.converter.spire.SpireWatermarkRemover;
 import com.spire.doc.FileFormat;
@@ -17,9 +16,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
-import java.util.List;
 
 public class FileService {
+
     public static final String BASE_PROMPT_PATH = "com/kimia/prompt/base-prompt.txt";
     public static final String INFO_EN_PATH = "/info/info-en.txt";
     public static final String INFO_FA_PATH = "/info/info-fa.txt";
@@ -52,6 +51,7 @@ public class FileService {
         path = resolveExternalPath(path);
         deleteIfExists(path);
         System.out.println("Creating Word document...");
+
         MarkdownConverter.convert(mdPath, path, FileFormat.Docx);
         System.out.println("Word file created.");
         SpireWatermarkRemover.removeWordWatermark(path);

--- a/src/main/resources/com/kimia/prompt/base-prompt.txt
+++ b/src/main/resources/com/kimia/prompt/base-prompt.txt
@@ -5,7 +5,7 @@ You are a professional career consultant. Based on the complete information prov
 1. Format the CV to fit approximately two pages in standard print layout. Do not include page numbers, pagination, or page breaks.  
 2. Output must be in **Markdown format only**.  
 3. Use the following section order. Omit any section with missing data:
-   - Personal Information  
+   - Personal Information (no section title)
    - Education  
    - Research and Publications  
    - Work Experience  
@@ -17,7 +17,7 @@ You are a professional career consultant. Based on the complete information prov
 4. Insert a line break followed by a horizontal separator (`---`) between each section.  
 5. Format all section titles as Header 1 (`# Title`) with an empty line after each title. Revise titles for clarity and professionalism if needed.  
 6. Apply these formatting rules:
-   - **Bold** institution names (e.g., universities, companies)  
+   - **Bold** personal information section
    - *Italicize* location names (e.g., city, country or branch)  
    - Hyperlink email addresses and web pages  
 7. List all entries in reverse chronological order (most recent first).  
@@ -25,8 +25,8 @@ You are a professional career consultant. Based on the complete information prov
    - Each academic experience must include **5 bullet points** highlighting achievements  
    - Each professional experience must include **3 bullet points** focused on technical, research, or academic accomplishments  
 9. For work-focused CVs:
-   - Each academic experience must include **3 bullet points**  
-   - Each professional experience must include **4 bullet points** focused on technical, research, or academic accomplishments  
+   - Each academic experience must include **3 bullet points** focused on skills, research, or academic accomplishments
+   - Each professional experience must include **4 bullet points** focused on skills and accomplishments
 10. Do not mention academic leave, withdrawal, or gaps. Emphasize strengths, contributions, and accomplishments.  
 11. If reference contact information is available, include full name, title, and institution.  
 12. **Format education and work entries as follows**:  
@@ -44,7 +44,7 @@ You are a professional career consultant. Based on the complete information prov
     - Soft Skills  
     Then list each skill as a bullet point under its category.
 
-### ✍️ Language and Style Requirements
+### Language and Style Requirements
 
 - Proofread and correct all grammar, spelling, and word choice errors  
 - Refine phrasing and sentence structure for clarity, fluency, and professionalism  
@@ -53,16 +53,16 @@ You are a professional career consultant. Based on the complete information prov
 - Use precise, action-oriented language aligned with international CV standards  
 - If the output is in Farsi:
   - Convert Gregorian dates to Jalali format (Day/Month/Year)  
-  - Ensure proper right-to-left formatting and localization for Persian dates and text  
-- Do not insert spaces between digits of phone numbers or between country code and number  
+  - Ensure proper right-to-left formatting and localization for Persian dates and text
+- If the output is in English convert jalali dates to Gregorian format
+- Maintain a single standard format for all phone numbers throughout
 - Remove all extra spaces between words or at the beginning/end of sentences  
 
-### ✅ Final Output Instructions
+### Final Output Instructions
 
 - The CV must be clean, modern, and ready for direct submission to universities or employers  
 - Output must be in **Markdown format only**, with all formatting rules applied  
 - Do not include any commentary, explanation, or introductory text  
 - Do not use triple backticks (` ``` `) to wrap the output  
 - Do not include a “CV Overview” section  
-- Use best-in-class CV examples as structural reference to ensure formatting and tone meet global standards  
-
+- Use best-in-class CV examples as structural reference to ensure formatting and tone meet global standards


### PR DESCRIPTION
### Summary

 Clarify and tighten prompt instructions to produce consistent Markdown CVs.
- Remove section header for personal information and emphasize bolding that section.
- Require 3 bullets for academic entries (skills/research/academic) and 4 bullets for professional entries (skills and accomplishments).
- Convert Jalali dates to Gregorian for English output and ensure RTL/localization for Farsi outputs.
- Standardize phone number formatting and remove extra spacing rules.
- Remove unnecessary emoji from headings and normalize the "Final Output" heading.
- Reference best-in-class examples for tone and structure.
- Tidy imports and adjust FileService formatting.